### PR TITLE
[ci-coach] ci: optimize CI workflow with path filtering, NuGet caching, and job timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,21 @@ name: CI
 on:
   push:
     branches: [ main ]
+    # Skip CI for documentation and image-only changes to avoid unnecessary runner usage
+    paths:
+      - 'Solutions/**'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [ main ]
+    paths:
+      - 'Solutions/**'
+      - '.github/workflows/ci.yml'
 
 jobs:
   build-csharp:
     runs-on: ubuntu-latest
+    # Prevent runaway jobs from consuming excess minutes
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       
@@ -16,12 +25,16 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
+          # Cache NuGet packages to avoid re-downloading on every run (~30-60s savings)
+          cache: true
+          cache-dependency-path: Solutions/CSharp/**/*.csproj
       
       - name: Build C# Solutions
         run: dotnet build Solutions/CSharp/CopilotAdventures.sln
   
   build-javascript:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       
@@ -37,6 +50,7 @@ jobs:
   
   build-python:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       


### PR DESCRIPTION
### Summary

Three targeted optimizations to the CI workflow that reduce unnecessary runner usage, speed up C# builds via caching, and guard against runaway jobs — with zero risk to correctness.

---

### Optimizations

#### 1. Path Filtering (Skip CI for non-code changes)

**Type**: Conditional Execution  
**Impact**: Saves **entire workflow runs** (~2–3 min each) when only docs or images are changed  
**Risk**: Low

**Changes**:
- Added `paths` filter to both `push` and `pull_request` triggers
- CI now only fires when files under `Solutions/**` or the workflow file itself change
- Pushes that only touch `Adventures/`, `Images/`, `*.md`, `Data/` etc. skip CI entirely

**Rationale**: The repository contains many markdown adventure files and images. Editing these should not consume CI minutes since no executable code changed.

<details>
<summary><b>Detailed Analysis</b></summary>

Before: Every push to `main` and every PR triggers 3 jobs × ~2 min = ~6 runner-minutes  
After: Documentation/image-only commits skip CI entirely

Estimated savings assuming ~30% of commits are doc-only: **~1.8 min saved per doc commit**

</details>

---

#### 2. NuGet Package Caching (C# build speedup)

**Type**: Cache Optimization  
**Impact**: ~30–60 seconds savings per C# build after first cache population  
**Risk**: Low (built-in feature of `actions/setup-dotnet@v4`)

**Changes**:
- Added `cache: true` and `cache-dependency-path` to the `actions/setup-dotnet@v4` step
- Uses the `.csproj` files as cache key — cache invalidates automatically when dependencies change

**Rationale**: Without caching, NuGet packages are re-downloaded on every run. The `setup-dotnet` action has native caching support that requires only two lines to enable.

<details>
<summary><b>Detailed Analysis</b></summary>

The `CopilotAdventures.csproj` has minimal dependencies (standard .NET 8 SDK), so cache size is small and hit rate should be very high (~95%+) since the project file rarely changes.

</details>

---

#### 3. Job Timeouts (Guard against runaway jobs)

**Type**: Resource Sizing  
**Impact**: Prevents wasted minutes if a job hangs (e.g., network issues during dotnet restore)  
**Risk**: Low

**Changes**:
- `build-csharp`: `timeout-minutes: 10`
- `build-javascript`: `timeout-minutes: 5`
- `build-python`: `timeout-minutes: 5`

**Rationale**: Without explicit timeouts, GitHub Actions defaults to 360 minutes. A hung job could silently consume 6 hours of runner time. These timeouts are generous for the actual work being done (typical runtimes are 1–2 min).

---

### Expected Impact

- **Time Savings**: ~30–60s per C# build run (caching) + full run skipped for doc-only changes
- **Cost Reduction**: Meaningful reduction in billable minutes for repos with frequent doc updates
- **Risk Level**: Low — all changes are additive configuration, no test/build logic modified

### Testing Recommendations

- [ ] Review workflow syntax (YAML is valid)
- [ ] Monitor first run after merge to confirm NuGet cache populates correctly
- [ ] Verify a doc-only commit (e.g., editing a `.md` file) correctly skips CI
- [ ] Confirm C# build still succeeds with cache enabled


<!-- gh-aw-tracker-id: ci-coach-daily -->




> Generated by [CI Optimization Coach](https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/24469342862/agentic_workflow) · ● 367K · [◷](https://github.com/search?q=repo%3AVirginia-Hamra%2Fcopilot-adventures-virginia+%22gh-aw-workflow-id%3A+ci-coach%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-04-17T17:50:41.528Z --> on Apr 17, 2026, 5:50 PM UTC

<!-- gh-aw-agentic-workflow: CI Optimization Coach, gh-aw-tracker-id: ci-coach-daily, engine: copilot, model: auto, id: 24469342862, workflow_id: ci-coach, run: https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/24469342862 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: ci-coach -->