### PR TITLE
[ci-coach] ci: add concurrency groups to cancel stale in-progress runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ on:
       - 'Solutions/**'
       - '.github/workflows/ci.yml'
 
+# Cancel any in-progress run for the same branch to avoid wasting runner minutes
+# on stale commits when multiple pushes arrive in quick succession.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-csharp:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary

Adds a `concurrency` group to the CI workflow so that stale in-progress runs are automatically cancelled when a newer commit is pushed to the same branch. This prevents wasting GitHub Actions runner minutes on builds that will be superseded.

### Optimizations

#### 1. Concurrency Group Auto-Cancellation

**Type**: Conditional Execution  
**Impact**: Eliminates 100% of wasted runner minutes on superseded runs (~1–2 min saved per redundant run)  
**Risk**: Low

**Changes**:
- Added top-level `concurrency` block keyed on `${{ github.workflow }}-${{ github.ref }}`
- Set `cancel-in-progress: true` to auto-cancel older runs for the same branch

**Rationale**: During active development, it's common to push multiple commits in quick succession (e.g., fixing a typo after a larger commit, or stacking commits). Without concurrency groups, all queued/running CI jobs continue to completion even though their results are irrelevant — the only run that matters is the latest one. This is pure waste.

<details>
<summary><b>Detailed Analysis</b></summary>

**Current state of the CI workflow (already well-optimized):**
- ✅ Path filtering — only triggers on `Solutions/**` changes (skips docs/images)
- ✅ All 3 build jobs are independent and run in parallel
- ✅ Tight timeouts (10 min for C#, 5 min for JS/Python)
- ✅ No unnecessary package installations (no `npm install`, `pip install`, or NuGet restore with packages)

**Gap identified:** No `concurrency` configuration meant back-to-back pushes would queue multiple full CI runs simultaneously.

**After this change:** A push to `main` (or a PR branch) while CI is already running will immediately cancel the in-progress run and start fresh with the latest commit — no wasted minutes.

</details>

### Expected Impact

- **Time Savings**: ~1–4 minutes per redundant run cancelled
- **Cost Reduction**: Proportional to how frequently multiple commits land on the same branch within a CI cycle
- **Risk Level**: Low — affects scheduling only; no test logic or build steps changed

### Testing Recommendations

- [x] Workflow YAML syntax is valid
- [ ] Monitor first few runs after merge to confirm cancellation behavior works as expected
- [ ] Compare runner minute usage before/after over a week of activity


<!-- gh-aw-tracker-id: ci-coach-daily -->




> Generated by [CI Optimization Coach](https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/24470428240/agentic_workflow) · ● 459.8K · [◷](https://github.com/search?q=repo%3AVirginia-Hamra%2Fcopilot-adventures-virginia+%22gh-aw-workflow-id%3A+ci-coach%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-04-17T18:15:23.051Z --> on Apr 17, 2026, 6:15 PM UTC

<!-- gh-aw-agentic-workflow: CI Optimization Coach, gh-aw-tracker-id: ci-coach-daily, engine: copilot, model: auto, id: 24470428240, workflow_id: ci-coach, run: https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/24470428240 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: ci-coach -->