### PR TITLE
[ci-coach] ci: fix .NET SDK version to explicitly match net9.0 target framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          # Explicitly request the SDK version matching the project's TargetFramework (net9.0)
+          dotnet-version: '9.0.x'
       
       - name: Build C# Solutions
         run: dotnet build Solutions/CSharp/CopilotAdventures.sln


### PR DESCRIPTION
### Summary

The `build-csharp` job in `.github/workflows/ci.yml` was installing the .NET **8** SDK (`dotnet-version: '8.0.x'`) while `CopilotAdventures.csproj` declares `<TargetFramework>net9.0</TargetFramework>`. Builds succeeded only because `ubuntu-latest` happens to ship .NET 9 pre-installed — a silent implicit dependency. This PR aligns the workflow with the project's actual target framework.

---

### Optimizations

#### 1. Correct .NET SDK Version (8.0.x → 9.0.x)

**Type**: Correctness / Resource Sizing  
**Impact**: Eliminates silent implicit dependency on runner's pre-installed SDK  
**Risk**: Low

**Changes**:
- Changed `dotnet-version: '8.0.x'` → `dotnet-version: '9.0.x'` in `build-csharp`

**Rationale**: `CopilotAdventures.csproj` declares `net9.0`. The previous workflow specified the .NET 8 SDK, meaning builds silently relied on the .NET 9 SDK pre-installed on `ubuntu-latest`. If that runner image is ever updated to drop .NET 9 or the project is built on a different runner, the build would fail with a "target framework not supported" error. Explicitly requesting `9.0.x` makes the workflow self-describing and resilient.

<details>
<summary><b>Detailed Analysis</b></summary>

**Evidence**:
- `Solutions/CSharp/CopilotAdventures.csproj`: `<TargetFramework>net9.0</TargetFramework>`
- `.github/workflows/ci.yml` (before): `dotnet-version: '8.0.x'`

This mismatch was previously identified in [PR #12](https://github.com/Virginia-Hamra/copilot-adventures-virginia/pull/12) (closed without merge). This PR isolates just the version fix as a minimal, safe change.

</details>

---

### Expected Impact

- **Time Savings**: Neutral (same job count/structure)
- **Correctness**: Removes reliance on pre-installed SDK; workflow now explicitly declares its toolchain requirement
- **Risk Level**: Low — `dotnet-version: '9.0.x'` matches the project's declared target; CI passes today only because the runner happens to have .NET 9 available anyway

### Testing Recommendations

- [ ] Review workflow YAML syntax
- [ ] Confirm C# build succeeds with `dotnet-version: '9.0.x'` in CI
- [ ] Monitor first run after merge to confirm no regressions


<!-- gh-aw-tracker-id: ci-coach-daily -->




> Generated by [CI Optimization Coach](https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/24531523796/agentic_workflow) · ● 547.7K · [◷](https://github.com/search?q=repo%3AVirginia-Hamra%2Fcopilot-adventures-virginia+%22gh-aw-workflow-id%3A+ci-coach%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-04-18T20:13:48.148Z --> on Apr 18, 2026, 8:13 PM UTC

<!-- gh-aw-agentic-workflow: CI Optimization Coach, gh-aw-tracker-id: ci-coach-daily, engine: copilot, model: auto, id: 24531523796, workflow_id: ci-coach, run: https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/24531523796 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: ci-coach -->