### PR TITLE
[ci-coach] ci: add NuGet caching and fix recursive JS validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           # Explicitly request the SDK version matching the project's TargetFramework (net9.0)
           dotnet-version: '9.0.x'
+          # Cache the global NuGet package store to avoid re-downloading packages on every run
+          cache: true
+          cache-dependency-path: Solutions/CSharp/**/*.csproj
       
       - name: Build C# Solutions
         run: dotnet build Solutions/CSharp/CopilotAdventures.sln
@@ -49,7 +52,9 @@ jobs:
       
       - name: Validate JavaScript Files
         run: |
-          for f in Solutions/JavaScript/*.js; do node --check "$f"; done
+          # Use find to recurse into subdirectories and catch all .js files,
+          # not just those at the top level of Solutions/JavaScript/
+          find Solutions/JavaScript -name "*.js" -print0 | xargs -0 -I{} node --check {}
           echo "JavaScript syntax validation passed"
   
   build-python:


### PR DESCRIPTION
### Summary

Two targeted improvements to `ci.yml` that reduce build time and close a validation coverage gap.

---

### Optimizations

#### 1. NuGet Package Caching

**Type**: Cache Optimization  
**Impact**: ~15–30s savings per `build-csharp` run  
**Risk**: Low

**Changes**:
- Added `cache: true` and `cache-dependency-path: Solutions/CSharp/**/*.csproj` to the `actions/setup-dotnet@v4` step

**Rationale**: Every CI run previously re-downloaded all NuGet packages from nuget.org. The built-in caching in `actions/setup-dotnet@v4` stores the global NuGet package store and restores it on cache hit. The cache key is derived from the `.csproj` files, so it automatically invalidates when dependencies change.

<details>
<summary><b>Detailed Analysis</b></summary>

- The `dotnet build` step implicitly runs `dotnet restore`, which downloads dependencies over the network on every run.
- `actions/setup-dotnet@v4` supports `cache: true` with an optional `cache-dependency-path` for precise cache keying.
- Cache key is a hash of all matching `*.csproj` files — invalidates automatically when packages change.

</details>

---

#### 2. Recursive JavaScript Syntax Validation

**Type**: Coverage Fix + Correctness  
**Impact**: 4 previously unchecked JS files now validated  
**Risk**: Low

**Changes**:
- Replaced `for f in Solutions/JavaScript/*.js` shell glob with `find Solutions/JavaScript -name "*.js" -print0 | xargs -0 -I{} node --check {}`

**Rationale**: The original glob pattern `*.js` only matched files directly in `Solutions/JavaScript/`, silently skipping all files in subdirectories. Four JS files were never syntax-checked:
- `Solutions/JavaScript/The-Gridlock-Arena-of-Mythos/The-Gridlock-Arena-of-Mythos.js`
- `Solutions/JavaScript/The-Gridlock-Arena-of-Mythos/demo-gridlock-arena.js`
- `Solutions/JavaScript/The-Gridlock-Arena-of-Mythos/The-Gridlock-Arena-of-Mythos.test.js`
- `Solutions/JavaScript/The-Knowledge-Cartographer-Agent-MCP/The-Knowledge-Cartographer-Agent-MCP.js`

The `find`-based approach is recursive and will automatically cover any new subdirectories added in the future. All existing files were verified locally with `node --check`.

---

### Expected Impact

- **Time Savings**: ~15–30s per run on `build-csharp` (after first cached run)
- **Coverage**: 4 additional JS files now validated on every PR
- **Risk Level**: Low — no logic changes, only caching config and glob fix

### Testing Recommendations

- [x] All JS files pass `node --check` locally (verified)
- [ ] Monitor first few runs to confirm NuGet cache hit on second run
- [ ] Compare `build-csharp` runtime before/after caching kicks in


<!-- gh-aw-tracker-id: ci-coach-daily -->




> Generated by [CI Optimization Coach](https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/24637812782/agentic_workflow) · ● 553.4K · [◷](https://github.com/search?q=repo%3AVirginia-Hamra%2Fcopilot-adventures-virginia+%22gh-aw-workflow-id%3A+ci-coach%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-04-21T20:02:07.436Z --> on Apr 21, 2026, 8:02 PM UTC

<!-- gh-aw-agentic-workflow: CI Optimization Coach, gh-aw-tracker-id: ci-coach-daily, engine: copilot, model: auto, id: 24637812782, workflow_id: ci-coach, run: https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/24637812782 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: ci-coach -->