### PR TITLE
[ci-coach] ci: add per-job path filtering to skip unnecessary language builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Detect which language directories changed so downstream jobs only run
+  # when their own files are modified, saving runner minutes on single-language commits.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      csharp:     ${{ steps.filter.outputs.csharp }}
+      javascript: ${{ steps.filter.outputs.javascript }}
+      python:     ${{ steps.filter.outputs.python }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            csharp:
+              - 'Solutions/CSharp/**'
+              - '.github/workflows/ci.yml'
+            javascript:
+              - 'Solutions/JavaScript/**'
+              - '.github/workflows/ci.yml'
+            python:
+              - 'Solutions/Python/**'
+              - '.github/workflows/ci.yml'
+
   build-csharp:
+    needs: changes
+    # Only rebuild when C# source or this workflow file changed
+    if: needs.changes.outputs.csharp == 'true'
     runs-on: ubuntu-latest
     # Prevent runaway jobs from consuming excess minutes
     timeout-minutes: 10
@@ -37,6 +65,9 @@ jobs:
         run: dotnet build Solutions/CSharp/CopilotAdventures.sln
   
   build-javascript:
+    needs: changes
+    # Only validate when JavaScript source or this workflow file changed
+    if: needs.changes.outputs.javascript == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -53,6 +84,9 @@ jobs:
           echo "JavaScript syntax validation passed"
   
   build-python:
+    needs: changes
+    # Only validate when Python source or this workflow file changed
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
### Summary

All three CI build jobs (C#, JavaScript, Python) currently run whenever **any** file in `Solutions/` changes. A commit that only adds a new `.py` file still waits for the C# SDK setup + `dotnet build` (~2 min) and the JavaScript syntax validator — wasting runner minutes with zero signal.

This PR adds a lightweight `changes` detector job that gates each build job behind a language-specific path filter, so only the relevant job(s) run.

---

### Optimizations

#### 1. Per-Job Path Filtering with `dorny/paths-filter`

**Type**: Conditional Execution  
**Impact**: ~66% savings in runner minutes for single-language commits  
**Risk**: Low

**Changes**:
- Added a `changes` job that uses `dorny/paths-filter@v3` to inspect which directories were modified
- Each build job now has `needs: changes` and an `if:` condition checking its language flag
- The workflow file itself (`ci.yml`) triggers all three jobs when edited, ensuring the workflow is always self-validating

**Rationale**: Adventures in this repository are developed in independent language subdirectories (`Solutions/CSharp/`, `Solutions/JavaScript/`, `Solutions/Python/`). Cross-language co-changes are rare. Gating each job on its own path filter eliminates the largest source of wasted runner minutes.

<details>
<summary><b>Detailed Analysis</b></summary>

**Before:**
````
Push touching Solutions/Python/*.py
  ├── build-csharp     (runs, ~2 min, unnecessary)
  ├── build-javascript (runs, ~30 sec, unnecessary)
  └── build-python     (runs, ~20 sec, necessary ✅)
Total: ~2 min 50 sec
```

**After:**
```
Push touching Solutions/Python/*.py
  ├── changes          (runs, ~15 sec, classifies paths ✅)
  ├── build-csharp     (skipped ⏭)
  ├── build-javascript (skipped ⏭)
  └── build-python     (runs, ~20 sec ✅)
Total: ~35 sec
````

The `changes` job adds ~15 seconds of overhead — negligible compared to the C# build it avoids. For CI workflow edits all three jobs still run as before.

</details>

---

### Expected Impact

- **Time Savings**: ~2 min per single-language commit (C# build avoided)
- **Cost Reduction**: Proportional to the fraction of commits that touch only one language (likely majority)
- **Risk Level**: Low — skipped jobs show as "skipped" (not failed) in GitHub's status checks, which is treated as a pass

### Testing Recommendations

- [ ] Review workflow YAML syntax
- [ ] Observe first run after merge — all three `changes` outputs should be `'true'` (since `ci.yml` itself changed)
- [ ] Make a Python-only commit on a branch and verify `build-csharp` and `build-javascript` are skipped
- [ ] Monitor runtime before/after for single-language PRs


<!-- gh-aw-tracker-id: ci-coach-daily -->




> Generated by [CI Optimization Coach](https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/24744117412/agentic_workflow) · ● 548.5K · [◷](https://github.com/search?q=repo%3AVirginia-Hamra%2Fcopilot-adventures-virginia+%22gh-aw-workflow-id%3A+ci-coach%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-04-23T20:18:45.186Z --> on Apr 23, 2026, 8:18 PM UTC

<!-- gh-aw-agentic-workflow: CI Optimization Coach, gh-aw-tracker-id: ci-coach-daily, engine: copilot, model: auto, id: 24744117412, workflow_id: ci-coach, run: https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/24744117412 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: ci-coach -->