### PR TITLE
[ci-coach] ci: use sparse checkout to skip 32 MB Images/ directory per job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Fetch only the C# source directory; Images/ (~32 MB) is not needed
+          sparse-checkout: Solutions/CSharp
       
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -41,6 +44,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Only the JS solution files are validated; skip Images/ (~32 MB)
+          sparse-checkout: Solutions/JavaScript
       
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -57,6 +63,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Only the Python solution files are validated; skip Images/ (~32 MB)
+          sparse-checkout: Solutions/Python
       
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
### Summary

Each CI job was downloading the entire repository — including the `Images/` directory (~32 MB of adventure artwork) — even though validation only needs code from a single `Solutions/` sub-directory (~328 KB). Adding `sparse-checkout` to each job's checkout step eliminates this unnecessary data transfer.

---

### Optimizations

#### 1. Sparse Checkout Per Job

**Type**: Artifact / Checkout Efficiency  
**Impact**: ~32 MB saved per job × 3 parallel jobs = ~96 MB less I/O per CI run  
**Risk**: Low

**Changes**:
- `build-csharp`: only fetches `Solutions/CSharp/`
- `build-javascript`: only fetches `Solutions/JavaScript/`
- `build-python`: only fetches `Solutions/Python/`

**Rationale**: The `Images/` directory contains 18 JPEG adventure artworks at 1456×832 resolution, totalling ~32 MB. No CI job reads these files — they exist solely for the README and adventure markdown. Sparse checkout excludes them entirely, reducing checkout time across all three parallel jobs.

<details>
<summary><b>Detailed Analysis</b></summary>

**Repository breakdown (via `du -sh`):**
| Directory | Size |
|-----------|------|
| `Images/` | 32 MB |
| `Solutions/` | 328 KB |
| `Adventures/` | 284 KB |
| `Data/` | 8 KB |

**Workflow structure before this change:**
- `build-csharp`, `build-javascript`, `build-python` each call `actions/checkout@v4` with no filters
- All three jobs download 32+ MB per checkout even though each job only uses <400 KB of source

**After this change:**
- Each job fetches only its relevant `Solutions/<lang>/` subdirectory
- `actions/checkout@v4` cone-mode sparse checkout handles this with a single `sparse-checkout:` input line
- No change to workflow logic, job dependencies, timeout settings, or path triggers

</details>

---

### Expected Impact

- **Data Savings**: ~96 MB per CI run (32 MB × 3 jobs)
- **Time Savings**: 5–15 seconds per job depending on runner network throughput
- **Risk Level**: Low — only the checkout scope changes; all validation commands remain identical

### Testing Recommendations

- [ ] Review workflow YAML syntax
- [ ] Confirm first run after merge fetches only the declared subdirectory
- [ ] Verify build artifacts (`.dll`, `--check`, `py_compile`) succeed as before


<!-- gh-aw-tracker-id: ci-coach-daily -->




> Generated by [CI Optimization Coach](https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/24857291035/agentic_workflow) · ● 654.3K · [◷](https://github.com/search?q=repo%3AVirginia-Hamra%2Fcopilot-adventures-virginia+%22gh-aw-workflow-id%3A+ci-coach%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-04-25T20:35:44.756Z --> on Apr 25, 2026, 8:35 PM UTC

<!-- gh-aw-agentic-workflow: CI Optimization Coach, gh-aw-tracker-id: ci-coach-daily, engine: copilot, model: auto, id: 24857291035, workflow_id: ci-coach, run: https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/24857291035 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: ci-coach -->