### PR TITLE
[ci-coach] ci: fix JS subdirectory coverage and add NuGet caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           # Explicitly request the SDK version matching the project's TargetFramework (net9.0)
           dotnet-version: '9.0.x'
+          # Cache NuGet packages to avoid re-downloading on every run
+          cache: true
+          cache-dependency-path: Solutions/CSharp/**/*.csproj
       
       - name: Build C# Solutions
         run: dotnet build Solutions/CSharp/CopilotAdventures.sln
@@ -49,7 +52,8 @@ jobs:
       
       - name: Validate JavaScript Files
         run: |
-          for f in Solutions/JavaScript/*.js; do node --check "$f"; done
+          # Use find to cover all subdirectories, not just the top level
+          find Solutions/JavaScript -name "*.js" -print0 | xargs -0 -I{} node --check "{}"
           echo "JavaScript syntax validation passed"
   
   build-python:


### PR DESCRIPTION
### Summary

Two concrete improvements to the CI workflow: a **correctness fix** for JavaScript validation coverage, and a **performance optimization** via NuGet package caching.

---

### Optimizations

#### 1. Fix JavaScript Validation Coverage

**Type**: Correctness / Test Coverage  
**Impact**: 4 previously-unvalidated JS files now checked on every run  
**Risk**: Low — purely additive change, no existing checks removed

**Changes**:
- Replace `for f in Solutions/JavaScript/*.js` (top-level glob only) with `find Solutions/JavaScript -name "*.js"` (recursive)

**Rationale**: The old shell glob `Solutions/JavaScript/*.js` only matches files in the *top-level* directory. Four JavaScript files live in subdirectories and were silently skipped:

| File | Status |
|------|--------|
| `Solutions/JavaScript/The-Gridlock-Arena-of-Mythos/The-Gridlock-Arena-of-Mythos.js` | ❌ Not validated before |
| `Solutions/JavaScript/The-Gridlock-Arena-of-Mythos/The-Gridlock-Arena-of-Mythos.test.js` | ❌ Not validated before |
| `Solutions/JavaScript/The-Gridlock-Arena-of-Mythos/demo-gridlock-arena.js` | ❌ Not validated before |
| `Solutions/JavaScript/The-Knowledge-Cartographer-Agent-MCP/The-Knowledge-Cartographer-Agent-MCP.js` | ❌ Not validated before |

All 4 files pass `node --check` (verified locally). Any future subdirectory JS additions will automatically be covered.

<details>
<summary><b>Before / After</b></summary>

```yaml
# Before — misses subdirectories
- name: Validate JavaScript Files
  run: |
    for f in Solutions/JavaScript/*.js; do node --check "$f"; done

# After — covers all subdirectories
- name: Validate JavaScript Files
  run: |
    find Solutions/JavaScript -name "*.js" -print0 | xargs -0 -I{} node --check "{}"
```

</details>

---

#### 2. NuGet Package Caching for C# Build

**Type**: Cache Optimization  
**Impact**: Saves ~20–40 seconds per C# build run by reusing cached packages  
**Risk**: Low — `actions/setup-dotnet` built-in caching, standard pattern

**Changes**:
- Add `cache: true` and `cache-dependency-path: Solutions/CSharp/**/*.csproj` to `actions/setup-dotnet@v4`

**Rationale**: Without caching, NuGet packages are re-downloaded on every run. The `cache-dependency-path` keyed on `.csproj` files ensures the cache is invalidated only when dependencies actually change.

<details>
<summary><b>Before / After</b></summary>

```yaml
# Before — no caching
- name: Setup .NET
  uses: actions/setup-dotnet@v4
  with:
    dotnet-version: '9.0.x'

# After — NuGet packages cached
- name: Setup .NET
  uses: actions/setup-dotnet@v4
  with:
    dotnet-version: '9.0.x'
    cache: true
    cache-dependency-path: Solutions/CSharp/**/*.csproj
```

</details>

---

### Expected Impact

- **Correctness**: 4 JS files now validated that were previously invisible to CI
- **Time Savings**: ~20–40s per C# build run (cache hits after first run)
- **Risk Level**: Low — both changes are well-established patterns with no behavior changes to passing tests

### Testing Recommendations

- [ ] Review workflow YAML syntax
- [ ] Monitor first run after merge to confirm NuGet cache is populated
- [ ] Verify JS validation output lists all 10 files (6 top-level + 4 in subdirs)


<!-- gh-aw-tracker-id: ci-coach-daily -->




> Generated by [CI Optimization Coach](https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/25018274947/agentic_workflow) · ● 627.4K · [◷](https://github.com/search?q=repo%3AVirginia-Hamra%2Fcopilot-adventures-virginia+%22gh-aw-workflow-id%3A+ci-coach%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-04-29T20:42:13.320Z --> on Apr 29, 2026, 8:42 PM UTC

<!-- gh-aw-agentic-workflow: CI Optimization Coach, gh-aw-tracker-id: ci-coach-daily, engine: copilot, model: auto, id: 25018274947, workflow_id: ci-coach, run: https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/25018274947 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: ci-coach -->