### PR TITLE
[ci-coach] ci: add NuGet caching and fix JS subdirectory validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           # Explicitly request the SDK version matching the project's TargetFramework (net9.0)
           dotnet-version: '9.0.x'
+          # Cache NuGet packages keyed on .csproj files to avoid re-downloading on every run
+          cache: true
+          cache-dependency-path: Solutions/CSharp/**/*.csproj
       
       - name: Build C# Solutions
         run: dotnet build Solutions/CSharp/CopilotAdventures.sln
@@ -49,7 +52,8 @@ jobs:
       
       - name: Validate JavaScript Files
         run: |
-          for f in Solutions/JavaScript/*.js; do node --check "$f"; done
+          # Use find for recursive discovery so files in subdirectories are also validated
+          find Solutions/JavaScript -name "*.js" -exec node --check {} \;
           echo "JavaScript syntax validation passed"
   
   build-python:


### PR DESCRIPTION
### Summary

Two concrete improvements to the CI workflow: **NuGet package caching** to speed up the C# build, and a **correctness fix** so JavaScript files in subdirectories are no longer silently skipped.

---

### Optimizations

#### 1. NuGet Package Caching for C# Build

**Type**: Cache Optimization  
**Impact**: ~20–40 seconds saved per C# build run on cache hits  
**Risk**: Low — uses the built-in `cache` input on `actions/setup-dotnet@v4`, the standard pattern

**Changes**:
- Add `cache: true` and `cache-dependency-path: Solutions/CSharp/**/*.csproj` to `actions/setup-dotnet@v4`

**Rationale**: Without caching, NuGet packages are re-downloaded on every run. Keying the cache on `.csproj` files ensures it is invalidated only when dependencies actually change.

```yaml
# Before — packages downloaded fresh every run
- name: Setup .NET
  uses: actions/setup-dotnet@v4
  with:
    dotnet-version: '9.0.x'

# After — NuGet packages cached between runs
- name: Setup .NET
  uses: actions/setup-dotnet@v4
  with:
    dotnet-version: '9.0.x'
    cache: true
    cache-dependency-path: Solutions/CSharp/**/*.csproj
```

---

#### 2. Recursive JavaScript Syntax Validation

**Type**: Correctness / Coverage  
**Impact**: 4 previously-unchecked JS files now validated on every push/PR  
**Risk**: Low — same `node --check` tool, broader file discovery; all 4 new files pass today

**Changes**:
- Replace `for f in Solutions/JavaScript/*.js` (top-level glob only) with `find Solutions/JavaScript -name "*.js"` (recursive)

**Rationale**: The shell glob `Solutions/JavaScript/*.js` only expands within the top-level directory. Four files in subdirectories were silently excluded:

| File | Syntax check |
|------|-------------|
| `The-Gridlock-Arena-of-Mythos/The-Gridlock-Arena-of-Mythos.js` | ✅ passes |
| `The-Gridlock-Arena-of-Mythos/The-Gridlock-Arena-of-Mythos.test.js` | ✅ passes |
| `The-Gridlock-Arena-of-Mythos/demo-gridlock-arena.js` | ✅ passes |
| `The-Knowledge-Cartographer-Agent-MCP/The-Knowledge-Cartographer-Agent-MCP.js` | ✅ passes |

```yaml
# Before — misses subdirectories
- name: Validate JavaScript Files
  run: |
    for f in Solutions/JavaScript/*.js; do node --check "$f"; done

# After — covers all subdirectories
- name: Validate JavaScript Files
  run: |
    find Solutions/JavaScript -name "*.js" -exec node --check {} \;
```

---

### Expected Impact

- **Time Savings**: ~20–40s per C# build run (NuGet cache hits after first warm run)
- **Coverage**: +4 JS files validated per run (previously invisible to CI)
- **Risk Level**: Low

### Testing Recommendations

- [ ] Review workflow YAML syntax
- [ ] Monitor first run after merge to confirm NuGet cache is populated
- [ ] Verify JS validation output includes all 10 files (6 top-level + 4 subdirectory)
- [ ] Compare `build-csharp` runtime before/after on second run (cache hit)

---

> Generated by [CI Optimization Coach](https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/25260643813/agentic_workflow) · Run #20


<!-- gh-aw-tracker-id: ci-coach-daily -->




> Generated by [CI Optimization Coach](https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/25260643813/agentic_workflow) · ● 635.3K · [◷](https://github.com/search?q=repo%3AVirginia-Hamra%2Fcopilot-adventures-virginia+%22gh-aw-workflow-id%3A+ci-coach%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-05-04T20:07:41.211Z --> on May 4, 2026, 8:07 PM UTC

<!-- gh-aw-agentic-workflow: CI Optimization Coach, gh-aw-tracker-id: ci-coach-daily, engine: copilot, model: auto, id: 25260643813, workflow_id: ci-coach, run: https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/25260643813 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: ci-coach -->