### PR TITLE
[ci-coach] ci: use sparse checkout to skip 32 MB of images per job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Only fetch the C# solutions — skips ~32 MB of images and other assets
+          sparse-checkout: Solutions/CSharp
       
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -41,6 +44,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Only fetch the JavaScript solutions — skips ~32 MB of images and other assets
+          sparse-checkout: Solutions/JavaScript
       
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -57,6 +63,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Only fetch the Python solutions — skips ~32 MB of images and other assets
+          sparse-checkout: Solutions/Python
       
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
### Summary

All three CI jobs currently perform a full repository checkout, including the `Images/` directory which contains **47 image files totalling ~32 MB**. None of these images are needed for compilation or syntax validation. Switching to sparse checkout limits each job to only its relevant `Solutions/` subdirectory, reducing unnecessary network transfer and disk I/O on every run.

### Optimizations

#### 1. Sparse Checkout per CI Job

**Type**: Resource / Artifact Management  
**Impact**: ~32 MB less data fetched per job (3 jobs × ~32 MB = ~96 MB per workflow run)  
**Risk**: Low

**Changes**:
- `build-csharp`: sparse-checkout `Solutions/CSharp`
- `build-javascript`: sparse-checkout `Solutions/JavaScript`
- `build-python`: sparse-checkout `Solutions/Python`

**Rationale**: Each job only reads files from its own language subdirectory. The `Images/` directory (32 MB, 47 files), `Adventures/` markdown files, and `Data/` files are never accessed during build or syntax validation. Sparse checkout is a native `actions/checkout@v4` feature and requires no additional tooling.

<details>
<summary><b>Detailed Analysis</b></summary>

**Repository layout contributing to oversized checkouts:**
```
Images/   → 32 MB, 47 files  (adventure artwork — not needed by any CI job)
Adventures/ → markdown files  (not needed by any CI job)
Data/     → scrolls.txt      (only needed at runtime, not compile time)
Solutions/CSharp/   → needed by build-csharp only
Solutions/JavaScript/ → needed by build-javascript only
Solutions/Python/   → needed by build-python only
```

**What each job actually reads:**
| Job | Files accessed |
|-----|---------------|
| build-csharp | `Solutions/CSharp/*.csproj`, `*.sln`, `*.cs` |
| build-javascript | `Solutions/JavaScript/*.js` |
| build-python | `Solutions/Python/*.py` |

No cross-directory reads occur in any of the three jobs.

</details>

### Expected Impact

- **Data savings**: ~32 MB per job, ~96 MB per full CI run
- **Time savings**: Modest checkout speedup (network + git object unpacking)
- **Risk Level**: Low — sparse checkout is stable in `actions/checkout@v4`; each job only needed its own subdirectory anyway

### Testing Recommendations

- [x] Workflow YAML syntax verified
- [ ] Monitor first run after merge to confirm each job finds expected files
- [ ] Compare checkout step timing before/after


<!-- gh-aw-tracker-id: ci-coach-daily -->




> Generated by [CI Optimization Coach](https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/25289436288/agentic_workflow) · ● 787.4K · [◷](https://github.com/search?q=repo%3AVirginia-Hamra%2Fcopilot-adventures-virginia+%22gh-aw-workflow-id%3A+ci-coach%22&type=pullrequests)
> - [x] expires <!-- gh-aw-expires: 2026-05-05T20:09:30.604Z --> on May 5, 2026, 8:09 PM UTC

<!-- gh-aw-agentic-workflow: CI Optimization Coach, gh-aw-tracker-id: ci-coach-daily, engine: copilot, model: auto, id: 25289436288, workflow_id: ci-coach, run: https://github.com/Virginia-Hamra/copilot-adventures-virginia/actions/runs/25289436288 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: ci-coach -->